### PR TITLE
docs: replace prescriptive test count guideline with concise, comprehensive guidance

### DIFF
--- a/docs/task_contribution.md
+++ b/docs/task_contribution.md
@@ -234,6 +234,10 @@ passes or fails.  Follow these rules to keep them fair and maintainable.
 For detailed statistics and patterns from SkillsBench, see the
 [SkillsBench unit test guidelines](https://github.com/benchflow-ai/skillsbench/blob/main/docs/unit-test-guidelines.md).
 
+### How many tests?
+
+Write as many tests as the task requires to fully verify correctness. Each test should cover a distinct, meaningful assertion — one per output metric, file section, or logical invariant. Avoid duplicating the same check with trivial variations, but do not artificially cap the count: a task with many output fields (e.g. per-asset risk contributions, multi-leg Greeks, reconciliation breaks) should have a test for each.
+
 ### Rules
 
 1. **Combine existence + content checks.**  Don't write a separate test for


### PR DESCRIPTION
## Summary

Replaces the rigid "How many tests?" table in `docs/task_contribution.md` with concise, principle-based guidance.

## Before

```
### How many tests?

| Task type | Recommended tests |
|---|---|
| Single output file (e.g. one JSON) | 1-3 |
| Multi-step pipeline (clean data + compute metrics) | 3-5 |
| Multiple distinct output artifacts | 5-8 |

Most tasks should have 3–5 tests. If you have more than 10, look for
opportunities to combine or parametrize.
```

## After

```
### How many tests?

Write as many tests as the task requires to fully verify correctness.
Each test should cover a distinct, meaningful assertion — one per output
metric, file section, or logical invariant. Avoid duplicating the same
check with trivial variations, but do not artificially cap the count:
a task with many output fields (e.g. per-asset risk contributions,
multi-leg Greeks, reconciliation breaks) should have a test for each.
```

## Rationale

The original table arbitrarily capped test counts at 3–8 and warned contributors away from writing >10 tests. This discourages thorough validation of complex tasks. The replacement keeps the intent (write focused, non-redundant tests) while removing the artificial ceiling.