### PR TITLE
Add evaluation and deploy-server test workflows

### DIFF
--- a/.github/scripts/test_on_server.py
+++ b/.github/scripts/test_on_server.py
@@ -263,7 +263,9 @@ def main() -> None:
 
     fetch_commands = [
         (["git", "fetch", "origin", f"pull/{args.pr_number}/head"], True),
+        (["git", "fetch", "upstream", f"pull/{args.pr_number}/head"], True),
         (["git", "fetch", "origin", args.head_ref], False),
+        (["git", "fetch", "upstream", args.head_ref], False),
     ]
 
     for cmd, is_pull_ref in fetch_commands:


### PR DESCRIPTION
## Summary

- `eval-on-approve.yml`: runs Harbor benchmarks on PR approval across multiple models (Claude, Gemini, Qwen, Mistral, MiniMax)
- `test-deploy.yml`: triggered by `/test-deploy` comment or manual dispatch, SSHes into deploy server to run oracle + Finance-Zero + claude-code
- `run_eval.py`: Harbor benchmark runner with results API posting
- `test_on_server.py`: deploy server validation (structure, canary, oracle, Finance-Zero, claude-code)

## Test plan
- [ ] Comment `/test-deploy` on a task PR to trigger deploy server test
- [ ] Verify oracle, Finance-Zero, and claude-code results appear in PR comment