### PR TITLE
Catch unhandled exceptions and write to results file

### DIFF
--- a/.github/scripts/test_on_server.py
+++ b/.github/scripts/test_on_server.py
@@ -353,4 +353,15 @@ def main() -> None:
 
 
 if __name__ == "__main__":
-    main()
+    try:
+        main()
+    except SystemExit:
+        raise
+    except Exception as exc:
+        import traceback
+        RESULTS_FILE.write_text(json.dumps({
+            "status": "error",
+            "error": f"Unhandled exception: {exc}",
+            "details": traceback.format_exc(),
+        }, indent=2))
+        sys.exit(1)


### PR DESCRIPTION
When test_on_server.py crashes with an unexpected exception (e.g. stale git state from a killed previous run), it previously exited silently, leaving the old results file untouched. The workflow would then post stale data from a prior PR instead of an error message.

Add a top-level try/except so any unhandled exception writes {"status": "error", "details": "..."} to the results file before exiting, making failures visible in the PR comment.

**If your PR is adding a new task to QuantitativeFinance-Bench, please complete this by adding an "x" next to each applicable item.**

- [ ]  I ran `harbor tasks check tasks/<task-id>` on my new task and ensured all checks pass
- [ ]  My `instruction.md` was written by a human
- [ ]  All behavior checked in tests is described in `instruction.md`
- [ ]  All behavior described in `instruction.md` is checked in tests
- [ ]  `instruction.md` does NOT mention which skills to use (agents must discover skills themselves)
- [ ]  My test cases have informative docstrings that describe which behavior they check
- [ ]  It is hard for the agent to cheat (e.g., editing data files, looking inside files for solution strings, etc.)
- [ ]  My `task.toml` was written by a human
- [ ]  My `solution/solve.sh` was written by a human (with minimal help from a language model)
- [ ]  If external dependencies are used, versions are pinned for reproducibility
- [ ]  If the agent produces structured data (API, JSON, CSV, etc.), the exact schema is documented in instruction.md or a referenced spec file
- [ ]  Skills are placed in `environment/skills/<skill-name>/SKILL.md`
- [ ]  Dockerfile copies skills to ALL agent paths (see checklist below)
- [ ]  Skills contain general guidance, NOT task-specific solutions
- [ ]  Skills would be useful for similar tasks, not just this one

**If your task includes skills, verify Dockerfile has:**
- [ ]  `COPY skills /root/.claude/skills` (Claude Code)
- [ ]  `COPY skills /etc/claude-code/.claude/skills` (Claude Code)
- [ ]  `COPY skills /root/.codex/skills` (Codex)
- [ ]  `COPY skills /root/.opencode/skill` (OpenCode - singular "skill", TESTED)
- [ ]  `COPY skills /root/.goose/skills` 
- [ ]  `COPY skills /root/.factory/skills` 
- [ ]  `COPY skills /root/.agents/skills` 

---

## Summary
Brief description of what the task tests. What skills does the agent need to demonstrate?


## Task Metadata

| Field | Value |
|-------|-------|
| **Task ID** | `your-task-id` |
| **Difficulty** | Easy / Medium / Hard - with justification |
| **Category** | e.g., financial-analysis, data-processing |
| **Skills Provided** | What skills are included and what guidance they provide |


## Agent Performance
- (required) harbor run -a 'oracle' passes.
- (required) run the task with skills and at least one powerful model (e.g., gpt-5.2, claude opus 4.6) in a scaffold that supports agent skills. Include analysis of failures.
- (required) run the task with the same model and scaffold but without skills. Compare with the previous run (can use metrics like number of unit tests passed). Can remove the skill by commenting out the COPY skills command in the Dockerfile or simply renaming the skills directory temporarily.
- (optional) run the task with `harbor run` with a harbor supported agent, e.g. Claude Code, Codex, Goose, etc.

## Screenshots / Evidence

### harbor tasks check
Screenshot or output of harbor tasks check passing

### Oracle Run
Screenshot showing oracle passing all tests

### Agent Runs
Screenshots of agent runs with and without skills. Also note here the `final_metrics` in `jobs/date/task-name__xxxxxx/agent/trajectory.json` for each run.

## Notes
Any additional context or explanations for checkbox items that don't fully apply