### PR TITLE
Fix Hull-White trinomial boundary probability signs

### DIFF
--- a/tasks/hull-white-swaption/solution/solve.py
+++ b/tasks/hull-white-swaption/solution/solve.py
@@ -220,15 +220,15 @@ class TrinomialTree:
             targets = (j + 1, j, j - 1)
         elif j == self.j_max:
             # Upper boundary: targets j, j-1, j-2
-            pu = 7.0 / 6.0 + (eta**2 + 3 * eta) / 2.0
-            pm = -1.0 / 3.0 - eta**2 - 2 * eta
-            pd = 1.0 / 6.0 + (eta**2 + eta) / 2.0
+            pu = 7.0 / 6.0 + (eta**2 - 3 * eta) / 2.0
+            pm = -1.0 / 3.0 - eta**2 + 2 * eta
+            pd = 1.0 / 6.0 + (eta**2 - eta) / 2.0
             targets = (j, j - 1, j - 2)
         elif j == -self.j_max:
             # Lower boundary: targets j+2, j+1, j
-            pu = 1.0 / 6.0 + (eta**2 - eta) / 2.0
-            pm = -1.0 / 3.0 - eta**2 + 2 * eta
-            pd = 7.0 / 6.0 + (eta**2 - 3 * eta) / 2.0
+            pu = 1.0 / 6.0 + (eta**2 + eta) / 2.0
+            pm = -1.0 / 3.0 - eta**2 - 2 * eta
+            pd = 7.0 / 6.0 + (eta**2 + 3 * eta) / 2.0
             targets = (j + 2, j + 1, j)
         else:
             # Should not happen with proper j_max

--- a/tasks/hull-white-swaption/solution/solve.sh
+++ b/tasks/hull-white-swaption/solution/solve.sh
@@ -222,14 +222,14 @@ def build_hw_tree(a, sigma, T_max, dt, logP_interp_func):
             eta2 = (a * j * dt)**2
 
             if j == j_max:
-                p_u = 7.0/6.0 + (eta2 + 3.0*eta) / 2.0
-                p_m = -1.0/3.0 - eta2 - 2.0*eta
-                p_d = 1.0/6.0 + (eta2 + eta) / 2.0
+                p_u = 7.0/6.0 + (eta2 - 3.0*eta) / 2.0
+                p_m = -1.0/3.0 - eta2 + 2.0*eta
+                p_d = 1.0/6.0 + (eta2 - eta) / 2.0
                 j_targets = (j, j-1, j-2)
             elif j == -j_max:
-                p_u = 1.0/6.0 + (eta2 - eta) / 2.0
-                p_m = -1.0/3.0 - eta2 + 2.0*eta
-                p_d = 7.0/6.0 + (eta2 - 3.0*eta) / 2.0
+                p_u = 1.0/6.0 + (eta2 + eta) / 2.0
+                p_m = -1.0/3.0 - eta2 - 2.0*eta
+                p_d = 7.0/6.0 + (eta2 + 3.0*eta) / 2.0
                 j_targets = (j+2, j+1, j)
             else:
                 p_u = 1.0/6.0 + (eta2 - eta) / 2.0


### PR DESCRIPTION
## Summary

Fix sign errors on the linear-in-η terms in the Hull-White trinomial tree upper/lower boundary branching probabilities. Applies to both `solution/solve.py` and the inline Python heredoc in `solution/solve.sh` of `tasks/hull-white-swaption/`.

## The bug

At the upper boundary (j = j_max, targets j, j−1, j−2), the correct Hull-White (1994) probabilities are

```
p_u = 7/6 + (η² − 3η)/2
p_m = −1/3 − η² + 2η
p_d = 1/6 + (η² − η)/2
```

where `η = a·j·Δt`. The previous code had every linear-in-η term with the opposite sign; the lower boundary had the mirrored three-sign flip. Derivation: match `E[Δstate] = −η` and `E[(Δstate)²] = 1/3 + η²` against offsets `(0, −1, −2)` with the probabilities summing to 1.

At the truncation threshold `|η| = 0.184`, the buggy code produced invalid probabilities `(p_u, p_m, p_d) = (1.460, −0.735, 0.276)`; the fix produces `(0.908, 0.000, 0.092)`.

## Impact on reference outputs

Numerical drift is confined to the longest-dated contract (5Yx5Y Bermudan), since that's where the tree assigns meaningful probability mass to boundary nodes:

| Output | Buggy | Fixed | Δ |
|---|---|---|---|
| 5Yx5Y Bermudan | 282.39 bps | 282.15 bps | −0.24 bps |
| 5Yx5Y premium | 43.48 bps | 43.24 bps | −0.24 bps |
| 5Yx5Y premium % | 18.20% | 18.10% | −0.10% |

All other quantities (European swaptions, DV01, calibration, 1Yx5Y / 2Yx3Y Bermudans, tree diagnostics) are unchanged to floating-point precision. Existing test tolerances absorb the 0.24 bps drift.

## Verification

- Oracle still passes **81/81** on the patched reference.
- Boundary formulas re-derived from first principles against Hull-White (1994) by first- and second-moment matching.

## Agent evaluation (for reference)

Ran `harbor run --path ./tasks --task-name hull-white-swaption --agent claude-code`:

| Agent | Model | Tests passed | Reward | Duration |
|---|---|---|---|---|
| oracle | — | 81/81 | 1.0 | 8s |
| claude-code | claude-opus-4-6 | 79/81 | 0.0 | 7m22s |
| claude-code | claude-sonnet-4-6 | 68/81 | 0.0 | 34m46s |

The task remains correctly calibrated as `very_hard`: Sonnet 4.6 fails comfortably; Opus 4.6 gets within 2 tests, and both of its failures are on the same 5Yx5Y tenor where the reference bug was most exposed (`test_tree_vs_analytical_close[5Yx5Y]` at 3.18 bps, tolerance 3.0 bps, and an exercise-boundary monotonicity slip on one adjacent pair).

## Test plan
- [x] Oracle passes 81/81 after fix
- [x] Diff against buggy reference confirms only 5Yx5Y Bermudan values shift (~0.24 bps)
- [x] Corrected formulas re-derived from first principles and checked against Hull-White (1994)

🤖 Generated with [Claude Code](https://claude.com/claude-code)