### PR TITLE
fix(creditrisk-plus-model): correct Gamma mixing variance formula

### DIFF
--- a/tasks/creditrisk-plus-model/instruction.md
+++ b/tasks/creditrisk-plus-model/instruction.md
@@ -26,7 +26,7 @@ Loss given default: $LGD = 0.45$ for all obligors.
 In CreditRisk+, each obligor's default is modeled as a Bernoulli event approximated by a Poisson random variable. Sector-level uncertainty is introduced via Gamma-distributed mixing variables that scale the default intensities of all obligors in a sector.
 
 For each sector $k$ with mean default rate $\mu_k$ (sum of PDs of obligors in sector $k$) and volatility $\sigma_k$:
-- The mixing variable $S_k$ follows a Gamma distribution with mean 1 and variance $\sigma_k^2 / \mu_k^2$
+- The mixing variable $S_k$ follows a Gamma distribution with mean 1 and variance $\sigma_k^2$
 - Conditional on $S_k$, each obligor in sector $k$ defaults independently with a Poisson intensity proportional to $S_k$
 
 The aggregate loss distribution is computed by:


### PR DESCRIPTION
## Problem

The instruction defines σ_k as the **volatility (standard deviation)** of sector default rates, but line 29 states:

> The mixing variable S_k follows a Gamma distribution with mean 1 and **variance σ_k² / μ_k²**

The `/μ_k²` term would only be correct if σ_k were a coefficient of variation (CV = std/mean). Since σ_k is a std, this is a contradiction.

All agents (Haiku, Sonnet, Opus) followed the explicit formula and computed wrong Gamma shape/scale parameters, producing systematically low VaR:
- Agent output: 5.9 / 7.7 / 10.2
- Oracle:       6.5 / 9.0 / 12.6

## Fix

Removed `/μ_k²` from line 29:

```diff
- The mixing variable $S_k$ follows a Gamma distribution with mean 1 and variance $\sigma_k^2 / \mu_k^2$
+ The mixing variable $S_k$ follows a Gamma distribution with mean 1 and variance $\sigma_k^2$
```

## Validation

After this fix, Haiku scores 30/30 (up from 25/30).

🤖 Generated with [Claude Code](https://claude.com/claude-code)