### PR TITLE
Fix Gordy granularity adjustment in credit-portfolio-var-cvar

### DIFF
--- a/tasks/credit-portfolio-var-cvar/instruction.md
+++ b/tasks/credit-portfolio-var-cvar/instruction.md
@@ -152,38 +152,36 @@ The Vasicek formula assumes an infinitely granular (perfectly diversified)
 portfolio. Real portfolios have name concentration, which the **Gordy
 granularity adjustment** corrects for.
 
-The granularity adjustment is:
+The granularity adjustment is derived from the **conditional variance** of the
+portfolio loss rate given the systematic factor at its worst-case realization.
+For each obligor $i$, the Vasicek conditional default probability is
+$\Phi(h_i(\alpha))$, so the conditional Bernoulli loss variance is
+$\Phi(h_i) \cdot [1 - \Phi(h_i)]$.
 
-$$\text{GA}(\alpha) = \frac{1}{2} \cdot \text{HHI}_{EL} \cdot \frac{C''(\alpha)}{C'(\alpha)}$$
-
-where $\text{HHI}_{EL}$ is the Herfindahl-Hirschman Index of
-exposure-LGD-weighted portfolio shares:
-
-$$\text{HHI}_{EL} = \frac{\sum_i (w_i \cdot \text{LGD}_i)^2}{\left(\sum_i w_i \cdot \text{LGD}_i\right)^2}$$
-
-with $w_i = \text{EAD}_i / \sum_j \text{EAD}_j$ being the exposure weight.
-
-**Conditional loss function derivatives.** Define the conditional default
-threshold for obligor $i$ at confidence level $\alpha$:
+**Conditional default threshold.** Define:
 
 $$h_i(\alpha) = \frac{\Phi^{-1}(\text{PD}_i) + \sqrt{\rho_i} \cdot \Phi^{-1}(\alpha)}{\sqrt{1 - \rho_i}}$$
 
 where $\Phi^{-1}$ is the standard normal quantile function and $\rho_i$ is
-the Basel asset correlation. The first derivative of $C(\alpha)$ is:
+the Basel asset correlation.
 
-$$C'(\alpha) = \sum_i w_i \cdot \text{LGD}_i \cdot \phi(h_i) \cdot \frac{\partial h_i}{\partial \alpha}$$
+**Conditional variance of portfolio loss rate** (with $w_i = \text{EAD}_i / M$,
+$M = \sum_j \text{EAD}_j$):
 
-where $\phi$ is the standard normal PDF, and:
+$$\sigma^2(\alpha) = \sum_i w_i^2 \cdot \text{LGD}_i^2 \cdot \Phi(h_i(\alpha)) \cdot \left[1 - \Phi(h_i(\alpha))\right]$$
 
-$$\frac{\partial h_i}{\partial \alpha} = \frac{\sqrt{\rho_i}}{\sqrt{1 - \rho_i} \cdot \phi(\Phi^{-1}(\alpha))}$$
+**Sensitivity of the conditional loss rate** to the confidence level:
 
-The second derivative is:
+$$C'(\alpha) = \sum_i w_i \cdot \text{LGD}_i \cdot \phi(h_i) \cdot \frac{\partial h_i}{\partial \alpha}, \qquad \frac{\partial h_i}{\partial \alpha} = \frac{\sqrt{\rho_i}}{\sqrt{1 - \rho_i} \cdot \phi(\Phi^{-1}(\alpha))}$$
 
-$$C''(\alpha) = \sum_i w_i \cdot \text{LGD}_i \left[ -h_i \cdot \phi(h_i) \cdot \left(\frac{\partial h_i}{\partial \alpha}\right)^2 + \phi(h_i) \cdot \frac{\partial^2 h_i}{\partial \alpha^2} \right]$$
+where $\phi$ is the standard normal PDF.
 
-where:
+**Granularity adjustment in USD** (Gordy & Lütkebohmert 2013):
 
-$$\frac{\partial^2 h_i}{\partial \alpha^2} = \frac{\sqrt{\rho_i} \cdot \Phi^{-1}(\alpha)}{\sqrt{1 - \rho_i} \cdot \left[\phi(\Phi^{-1}(\alpha))\right]^2}$$
+$$\text{GA}(\alpha) = \frac{M \cdot \sigma^2(\alpha)}{2 \cdot C'(\alpha)}$$
+
+For $N$ equally-weighted obligors $\sigma^2 \sim 1/N$, so
+$\text{GA} \to 0$ as $N \to \infty$, recovering the Vasicek limit.
 
 **Note:** Only include obligors with $\text{PD}_i > 0$ in these sums, as
 $\Phi^{-1}(0) = -\infty$.

--- a/tasks/credit-portfolio-var-cvar/solution/solve.py
+++ b/tasks/credit-portfolio-var-cvar/solution/solve.py
@@ -190,20 +190,17 @@ for alpha in CONF_LEVELS:
 
     C_prime = float(np.sum(weights[valid] * lgd[valid] * phi_h[valid] * dh_dalpha[valid]))
 
-    d2h_dalpha2 = np.zeros(N)
-    d2h_dalpha2[valid] = np.sqrt(rho[valid]) * z_alpha / (np.sqrt(1.0 - rho[valid]) * phi_z ** 2)
-    C_double_prime = float(np.sum(
-        weights[valid] * lgd[valid] * (
-            -h[valid] * phi_h[valid] * dh_dalpha[valid] ** 2
-            + phi_h[valid] * d2h_dalpha2[valid]
-        )
+    # Conditional default probability Φ(h_i) for each obligor at this α
+    cond_pd_at_alpha = stats.norm.cdf(h[valid])
+
+    # Conditional variance of portfolio loss rate: Σ w_i² × LGD_i² × Φ(h_i)(1-Φ(h_i))
+    cond_var_rate = float(np.sum(
+        weights[valid] ** 2 * lgd[valid] ** 2
+        * cond_pd_at_alpha * (1.0 - cond_pd_at_alpha)
     ))
 
-    # Exposure HHI weighted by LGD
-    weighted_exp = weights * lgd
-    hhi_ead_lgd = float(np.sum(weighted_exp ** 2) / (np.sum(weighted_exp)) ** 2)
-
-    ga = 0.5 * hhi_ead_lgd * C_double_prime / C_prime if abs(C_prime) > 1e-15 else 0.0
+    # Gordy GA in USD: total_exposure × σ²(α) / (2 × C'(α))
+    ga = total_exposure * cond_var_rate / (2.0 * C_prime) if abs(C_prime) > 1e-15 else 0.0
     gordy_var = v_var + ga
 
     gordy_rows.append({

--- a/tasks/credit-portfolio-var-cvar/tests/test_outputs.py
+++ b/tasks/credit-portfolio-var-cvar/tests/test_outputs.py
@@ -691,10 +691,27 @@ class TestGranularityAdjustment:
                     f"Vasicek VaR ({row['vasicek_var']:.2f}) at " \
                     f"{row['confidence_level']}"
 
+    def test_ga_meaningful_magnitude(self, df):
+        """Granularity adjustment must be a dollar-denominated quantity.
+
+        A correct implementation of the Gordy conditional-variance formula
+        yields GA in the range [$1 000, 5% × Vasicek VaR].  Returning a
+        dimensionless rate (e.g. 0.056) and adding it directly to a USD
+        VaR produces GA ≈ $0.06 — caught here.
+        """
+        for _, row in df.iterrows():
+            if row["confidence_level"] >= 0.99:
+                assert row["granularity_adjustment"] >= 1_000, (
+                    f"GA = {row['granularity_adjustment']:.2f} at "
+                    f"{row['confidence_level']} — appears dimensionless; "
+                    "expected a USD amount ≥ $1 000"
+                )
+
     def test_gordy_close_to_vasicek(self, df):
-        """For a well-diversified portfolio (990 obligors), the
+        """For a well-diversified portfolio (~{N_OBLIGORS} obligors), the
         granularity adjustment should be small relative to Vasicek VaR
-        (< 5% of Vasicek VaR)."""
+        (< 5% of Vasicek VaR).  Proportional to 1/N, so it vanishes as
+        the portfolio becomes more granular."""
         for _, row in df.iterrows():
             if row["vasicek_var"] > 0:
                 pct = abs(row["granularity_adjustment"]) / row["vasicek_var"] * 100


### PR DESCRIPTION
## Summary

- **Bug**: The Gordy granularity adjustment used the formula `GA = ½ × HHI_EL × C''(α)/C'(α)`, which produces a dimensionless number (~0.056). Adding this directly to a USD VaR (~\$465M) yields a ~\$0.06 adjustment — economically meaningless and financially incorrect.
- **Fix**: Replace with the correct Gordy–Lütkebohmert (2013) conditional-variance formula: `GA(α) = M × σ²(α) / (2 × C'(α))`, where `σ²(α) = Σ wᵢ² × LGDᵢ² × Φ(hᵢ) × [1 − Φ(hᵢ)]` is the conditional variance of the portfolio loss rate. This produces a dollar-denominated GA (~\$370K, ~0.08% of Vasicek VaR for this 990-obligor portfolio), consistent with the expected 1/N granularity scaling.
- **New test**: `test_ga_meaningful_magnitude` asserts `GA ≥ $1,000` at 99%+ confidence, catching any future regression where a dimensionless rate is added to a USD VaR.

## Files changed

- `instruction.md` — rewrite Gordy section with correct conditional-variance formula; remove C'' and ∂²h/∂α² derivations
- `solution/solve.py` — replace d2h/C_double_prime/HHI computation with `cond_pd_at_alpha` + `cond_var_rate`; fix dimensional mismatch (`ga = total_exposure × cond_var_rate / (2 × C_prime)`)
- `tests/test_outputs.py` — add `test_ga_meaningful_magnitude`

## Test plan

- [x] Oracle: reward = 1.0
- [x] Claude Code (Sonnet 4.6): reward = 1.0 (6m 18s)
- [x] Claude Code (Opus 4.7): reward = 1.0 (4m 20s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)