### PR TITLE
Fix D1 spec-test gaps in 3 tasks

### DIFF
--- a/tasks/dupire-local-vol/instruction.md
+++ b/tasks/dupire-local-vol/instruction.md
@@ -62,7 +62,7 @@ Compute derivatives:
 Generate synthetic market data with constant implied vol σ = 0.20 across a moderate near-the-money strike grid and multiple expiries. This is a diagnostic identity check, not a tail stress test: under a constant Black-Scholes implied volatility surface, Dupire local volatility should recover the same constant volatility across the diagnostic grid. Choose the grid and numerical derivatives so this check isolates Dupire/Black-Scholes consistency rather than deep-tail or finite-difference instability.
 
 **(b) Forward Variance Check:**
-For each expiry T, compute the forward variance (the time derivative of total variance). This must be positive everywhere (calendar arbitrage free).
+For each expiry T, compute the forward variance (the time derivative of total variance) as the difference in total variance between consecutive expiries divided by their time gap. Forward variance must be positive for all interior expiry periods (all periods except the last, where no subsequent expiry exists to form a difference). A calendar-arbitrage-free SVI calibration should produce positive forward variances for at least 90% of interior periods.
 
 **(c) Local Vol Positivity:**
 Verify that σ_loc(K, T) > 0 for all grid points.

--- a/tasks/dupire-local-vol/tests/test_outputs.py
+++ b/tasks/dupire-local-vol/tests/test_outputs.py
@@ -265,12 +265,16 @@ class TestForwardVariance:
         assert (fwd_var_df['total_variance'] > 0).all()
 
     def test_forward_variance_positive(self, fwd_var_df):
-        # Forward variance should be positive at least half the time
-        # Numerical noise and curve fitting can cause some negative values
-        if len(fwd_var_df) > 1:
-            # At least 40% should be positive
-            positive_count = (fwd_var_df.iloc[1:]['forward_variance'] > 0).sum()
-            assert positive_count >= 0.4 * (len(fwd_var_df) - 1)
+        # Forward variance is computed as the difference in total variance between
+        # consecutive expiries.  The last row has no next expiry and is therefore
+        # undefined (stored as 0); exclude it.  Interior forward variances must be
+        # positive (calendar arbitrage free) for a well-calibrated SVI surface.
+        if len(fwd_var_df) > 2:
+            interior = fwd_var_df.iloc[:-1]  # drop the last (undefined) row
+            positive_count = (interior['forward_variance'] > 0).sum()
+            assert positive_count >= 0.9 * len(interior), (
+                f"Only {positive_count}/{len(interior)} interior forward variances are positive"
+            )
 
     def test_forward_variance_local_vol_atm_positive(self, fwd_var_df):
         assert (fwd_var_df['local_vol_atm'] > 0).all()
@@ -313,5 +317,3 @@ class TestSummary:
 
     def test_summary_forward_var_positive(self, summary):
         assert isinstance(summary['forward_var_positive'], bool)
-        # Note: Due to numerical noise, we relax this constraint
-        # The important thing is that local vols are positive and the model is calibrated

--- a/tasks/fx-forward-cross-rate/instruction.md
+++ b/tasks/fx-forward-cross-rate/instruction.md
@@ -68,11 +68,26 @@ by pair (10000 for most, 100 for JPY crosses).
 Construct spot and 3M forward cross rates for all pairs listed in
 `params.json` by triangulating through the underlying USD pairs.
 
-For bid/ask, think about which side of each USD leg a dealer would
-actually trade to replicate the cross-forward exposure; apply those
-matching sides consistently so that the resulting cross forward bid/ask
-reflects the interbank hedge rather than a single scaling of the
-cross-spot spread.
+For bid/ask, apply the following triangulation rule. When both USD legs
+are quoted as `XXX/USD` (USD is the quote currency — e.g. GBP/USD,
+EUR/USD, AUD/USD), and the cross is `XXX/YYY`:
+
+- **Cross bid** = `XXX/USD bid` × `USD/YYY bid`
+  (sell XXX → buy USD at bid; sell USD → buy YYY at USD/YYY bid, i.e. `1 / (YYY/USD ask)`)
+- **Cross ask** = `XXX/USD ask` × `USD/YYY ask`
+  (buy XXX → sell USD at ask; buy USD → sell YYY at USD/YYY ask, i.e. `1 / (YYY/USD bid)`)
+
+When one leg is quoted as `USD/ZZZ` (USD is the base — e.g. USD/JPY,
+USD/CHF), first convert to `ZZZ/USD = 1 / (USD/ZZZ)` and apply the
+formula above, flipping bid/ask in the reciprocal. For example, for
+GBP/JPY using GBP/USD and USD/JPY:
+
+- `GBP/JPY mid  = GBP/USD mid  × USD/JPY mid`
+- `GBP/JPY bid  = GBP/USD bid  × USD/JPY bid`
+- `GBP/JPY ask  = GBP/USD ask  × USD/JPY ask`
+
+Apply the same formula for forward cross rates, substituting the
+relevant tenor's forward bid/ask in place of spot bid/ask.
 
 ### Part 3: Portfolio Valuation
 

--- a/tasks/mc-greek-surface-1/instruction.md
+++ b/tasks/mc-greek-surface-1/instruction.md
@@ -108,7 +108,11 @@ The likelihood ratio method weights the payoff by the log-derivative of the unde
 
 - **Delta** (dollars per 1% spot move): Weight payoff by `Z / (S₀ σ √T)`. This produces the score function with respect to log-spot.
 
-- **Gamma** (delta per 1% spot move): Requires the second derivative of the log-likelihood with respect to log-spot.
+- **Gamma** (delta per $1 spot move): Use the score function for the second derivative of the log-likelihood with respect to S₀:
+
+  $$\Gamma^{\text{LR}} = e^{-rT} \cdot \mathbb{E}\!\left[\text{payoff}(S_T) \cdot \frac{Z^2 - 1 - Z\,\sigma\sqrt{T}}{(S_0\,\sigma\,\sqrt{T})^2}\right]$$
+
+  where $Z = \bigl(\ln(S_T/S_0) - (r - q - \tfrac{1}{2}\sigma^2)T\bigr)/(\sigma\sqrt{T})$ is the standard normal draw used to simulate $S_T$. This estimator is noisier than FD gamma; allow 10% tolerance against the BS benchmark.
 
 - **Vega** (dollars per 1% volatility change): Weight by `payoff × [(Z² − 1) / σ − Z√T]`. This is the score function with respect to log-volatility.
 


### PR DESCRIPTION
## Summary

Three tasks had confirmed D1 (Output Schema / Spec Compliance) issues where the instruction and the verifier disagreed in ways that could cause a correctly-implemented agent to fail the benchmark.

- **`dupire-local-vol`**: Spec said forward variance "must be positive everywhere"; verifier accepted ≥40%. Root cause: the oracle always writes `forward_variance = 0` for the last expiry (no next tenor to difference against), so the verifier must exclude that boundary row. New test excludes the last row and requires ≥90% of interior values to be positive, consistent with the updated spec language.

- **`mc-greek-surface-1`**: Spec said LR Gamma "requires the second derivative of the log-likelihood" but gave no formula. Verifier asserts a non-null value within 10% of BS Gamma. Added the explicit score-function estimator so agents know what to compute: `Γ_LR = e^{-rT} · E[payoff · (Z²−1−Zσ√T) / (S₀σ√T)²]`.

- **`fx-forward-cross-rate`**: Spec gave only conceptual guidance ("think about which side a dealer would trade") while the verifier asserts specific cross-rate mid values to 5×10⁻⁴ tolerance. Added the explicit bid×bid / ask×ask triangulation formula with a GBP/JPY worked example.

## Test plan

- [ ] Run oracle on `dupire-local-vol` — confirm all tests still pass with new 90% threshold
- [ ] Run oracle on `mc-greek-surface-1` — confirm LR Gamma test passes
- [ ] Run oracle on `fx-forward-cross-rate` — confirm cross-rate tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)