### PR TITLE
Fix B2: specify PC1 sign-fixing rule in lob-pc-signal

### DIFF
--- a/tasks/barrier-garch-var/instruction.md
+++ b/tasks/barrier-garch-var/instruction.md
@@ -12,6 +12,17 @@ option analytically with Greeks, and computes a parametric VaR
 decomposition for a portfolio of `n_contracts` options at the given
 confidence level.
 
+For pricing, use the conditional volatility from the GARCH(1,1) model
+at the final observation in the return series — reflecting the current
+volatility regime — annualized using 252 trading days per year. The
+long-run (unconditional) variance is reported separately as an
+intermediate checkpoint.
+
+In the VaR decomposition, `delta_var_pct`, `gamma_var_pct`, and
+`vega_var_pct` represent each Greek factor's percentage share of total
+portfolio variance (not its share of portfolio VaR), so the three
+percentages sum to 100%.
+
 ## Input Files
 
 - `/app/data/returns.csv` -- columns: `date`, `log_return` (750 rows).

--- a/tasks/lob-pc-signal/instruction.md
+++ b/tasks/lob-pc-signal/instruction.md
@@ -106,4 +106,4 @@ Output should be in the following format:
   follow this, you will deviate from the expected results.
 - If the target is missing for a training block, just skip it.
 - random state should be fixed to 0
-- the consecutive changes in PCA component should be minimalized
+- Fix the sign of PC1 so that its correlation with the level-0 weighted OFI feature (`weighted_ofi_0`) is non-negative: if `corr(PC1_train, weighted_ofi_0_train) < 0`, multiply PC1 by −1 before fitting the OLS model and before transforming any new observation.


### PR DESCRIPTION
## Summary

- The spec said only "the consecutive changes in PCA component should be minimalized" with no algorithm.
- The oracle uses a specific deterministic rule: flip PC1 if `corr(PC1_train, weighted_ofi_0_train) < 0`.
- Without an explicit rule, agents choose different sign conventions, producing numerically incompatible `rolling_pc1` series and consequently different predicted returns.
- Fix: replace the vague sentence with the exact rule, including the application to out-of-sample transforms.

## Test plan

- [x] Oracle run after change: reward = 1.000.

🤖 Generated with [Claude Code](https://claude.com/claude-code)