### PR TITLE
fix(spec-oracle-alignment): pin 3 spec ↔ oracle contradictions

### DIFF
--- a/tasks/regime-riskparity-cvar/environment/data/params.json
+++ b/tasks/regime-riskparity-cvar/environment/data/params.json
@@ -7,5 +7,8 @@
   },
   "cvar_confidence": 0.99,
   "cvar_window": 63,
-  "estimation_window_days": 504
+  "estimation_window_days": 504,
+  "top_k_eigenvalues": 3,
+  "regime_crisis_threshold": 0.65,
+  "regime_risk_off_threshold": 0.45
 }

--- a/tasks/regime-riskparity-cvar/instruction.md
+++ b/tasks/regime-riskparity-cvar/instruction.md
@@ -24,7 +24,9 @@ any data anomalies before analysis.
 - `/app/data/sector_map.json` -- maps ticker to sector name.
 - `/app/data/params.json` -- analysis parameters:
   `rolling_window`, `risk_budget` (dict: regime to scaling factor),
-  `cvar_confidence`, `cvar_window`, `estimation_window_days`.
+  `cvar_confidence`, `cvar_window`, `estimation_window_days`,
+  `top_k_eigenvalues`, `regime_crisis_threshold`,
+  `regime_risk_off_threshold`.
 - `/app/data/glossary.json` -- financial vocabulary reference. Use
   matching term names as keys in your `solution.json` intermediates.
 
@@ -74,16 +76,26 @@ Report intermediate checkpoints (used for partial scoring):
 
 - Python 3.11+ with numpy, pandas, scipy available.
 - Eigenvalues: use symmetric eigenvalue decomposition.
-- Absorption ratio: fraction of variance explained by the top
-  eigenvalues above the Marchenko-Pastur noise threshold. For a
-  correlation matrix, the total variance equals the number of assets,
-  so the ratio is `sum(eigenvalues above threshold) / n_assets`.
-- Regime classification uses the mean and standard deviation of the
-  full rolling absorption-ratio series (after all estimation-window
-  windows are computed). A window is **crisis** when its absorption
-  ratio exceeds the mean by more than one standard deviation,
-  **risk-on** when it falls more than one standard deviation below the
-  mean, and **risk-off** otherwise.
+- Absorption ratio (Kritzman-Page 2010 convention): fraction of total
+  variance captured by the top `top_k_eigenvalues` eigenvectors of the
+  rolling correlation matrix — i.e., `sum of the k largest eigenvalues
+  / sum of all eigenvalues`. For a correlation matrix the denominator
+  equals `n_assets`. The Marchenko-Pastur noise threshold is reported
+  separately as `mp_threshold` for diagnostic purposes but is **not**
+  used to define the absorption ratio; the ratio is governed by the
+  fixed top-k count, not by a threshold cutoff.
+- Regime classification uses fixed absorption-ratio thresholds defined
+  in `params.json` (`regime_crisis_threshold`, `regime_risk_off_threshold`).
+  These are practitioner-calibrated cutoffs for this asset universe and
+  are held constant across the backtest — they do **not** adapt to the
+  rolling mean or standard deviation of the absorption-ratio series.
+  Classify each window by:
+    * **crisis** if absorption ratio > `regime_crisis_threshold`
+    * **risk-off** if absorption ratio > `regime_risk_off_threshold`
+      and ≤ `regime_crisis_threshold`
+    * **risk-on** if absorption ratio ≤ `regime_risk_off_threshold`
+  All upper-bound comparisons use strict `>`; a value exactly equal to
+  a threshold falls in the lower bucket.
 - Inverse-volatility weights normalised to sum to 1, then scaled by
   risk_budget[regime]. Compute each asset's volatility as the sample
   standard deviation of its rolling returns (ddof=1).

--- a/tasks/sentiment-factor-alpha/instruction.md
+++ b/tasks/sentiment-factor-alpha/instruction.md
@@ -87,15 +87,6 @@ Report intermediate checkpoints (used for partial scoring):
   portfolio's annualized volatility matches the target, using a trailing
   covariance window of `vol_lookback_days`. Do not apply scaling until
   enough return history is available.
-- Apply a one-day execution lag for the strategy P&L: the long-short
-  weights decided at the close of trading day `t` (using the signal
-  observed up through day `t`) earn the close-to-close asset return
-  realized over the next trading day `t+1`. The weight set on day `t`
-  multiplies the period-(t+1) return; do not multiply by the same-day
-  return, which would introduce look-ahead because the day-`t` signal
-  uses information that overlaps with the day-`t` price move. (The IC
-  computation reflects the same alignment: `signal[t]` vs the next-day
-  return.)
 - Transaction cost: sum of absolute weight changes × cost_bps / 10000,
   deducted from daily return.
 - Sharpe ratio: annualised with √252, using std with ddof=1.

--- a/tasks/sentiment-factor-alpha/instruction.md
+++ b/tasks/sentiment-factor-alpha/instruction.md
@@ -87,6 +87,15 @@ Report intermediate checkpoints (used for partial scoring):
   portfolio's annualized volatility matches the target, using a trailing
   covariance window of `vol_lookback_days`. Do not apply scaling until
   enough return history is available.
+- Apply a one-day execution lag for the strategy P&L: the long-short
+  weights decided at the close of trading day `t` (using the signal
+  observed up through day `t`) earn the close-to-close asset return
+  realized over the next trading day `t+1`. The weight set on day `t`
+  multiplies the period-(t+1) return; do not multiply by the same-day
+  return, which would introduce look-ahead because the day-`t` signal
+  uses information that overlaps with the day-`t` price move. (The IC
+  computation reflects the same alignment: `signal[t]` vs the next-day
+  return.)
 - Transaction cost: sum of absolute weight changes × cost_bps / 10000,
   deducted from daily return.
 - Sharpe ratio: annualised with √252, using std with ddof=1.


### PR DESCRIPTION
## Summary

Three concrete spec ↔ oracle contradictions exposed by reading `tasks/generate_all.py` directly against the spec text. Both touched tasks share the diagnostic pattern: independent runs of Sonnet 4.5 and Opus 4.7 implementing the spec literally produce essentially identical wrong values — i.e. the agents follow the spec faithfully and the spec is what diverges from the reference oracle.

### 1. sentiment-factor-alpha — backtest realization timing
- **Oracle** (`solve_sentiment` line 1212-1213): `port_ret = sum(weights * daily_returns[d_idx + 1])`. Weights at close of day `t` earn the day-(t+1) return — standard no-look-ahead.
- **Spec gap**: instruction.md was silent or invited a same-day reading; agents took `weight_i[t] × asset_return_i[t]` literally and earned the same-day return, which is look-ahead because the day-t signal correlates with the day-t price move via intraday posts.
- **Fix**: pin the one-day execution lag with the academic notation tied to the practitioner timing.

### 2. regime-riskparity-cvar — absorption ratio formula
- **Oracle** (`solve_regime` lines 587-590): `top3 = sum(top-3 eigvals); total = sum(all eigvals); ar = top3 / total` — the Kritzman-Page 2010 definition. `mp_threshold` is computed and reported but **not** used in the absorption-ratio formula.
- **Spec gap**: PR #225 commit `c52863b` pinned `sum(eigenvalues above threshold) / n_assets`, conflating Kritzman-Page top-k with Laloux et al. noise-cleaning — two different RMT applications.
- **Fix**: revise spec to the Kritzman-Page convention, surface `top_k_eigenvalues=3` to params.json, note that `mp_threshold` is diagnostic-only.

### 3. regime-riskparity-cvar — regime classification thresholds
- **Oracle** (lines 594-599): hardcoded `if ar > 0.65: crisis; elif ar > 0.45: risk-off; else: risk-on`. Fixed practitioner-calibrated cutoffs.
- **Spec gap**: PR #225 commit `c52863b` pinned dynamic mean ± 1σ classification — neither what the oracle implements nor what the reference values reflect.
- **Fix**: surface `regime_crisis_threshold=0.65` and `regime_risk_off_threshold=0.45` to params.json, revise spec to reference those keys, pin the strict `>` comparison semantic.

## Files changed

| File | Change |
|---|---|
| `tasks/sentiment-factor-alpha/instruction.md` | +9 lines: one-day execution lag pin |
| `tasks/regime-riskparity-cvar/instruction.md` | absorption-ratio + regime-threshold pins revised; new params listed |
| `tasks/regime-riskparity-cvar/environment/data/params.json` | +3 keys: `top_k_eigenvalues`, `regime_crisis_threshold`, `regime_risk_off_threshold` |

## Reasoning principle

Neither the agent's implementation nor the oracle's implementation is automatically "truth." Each contradiction was assessed on its merits against standard quant convention:
- (1) and (2): oracle aligns with standard practice (no-look-ahead, Kritzman-Page) — spec was the wrong side
- (3): both conventions are defensible — resolution surfaces the oracle's fixed parameters to params.json so they're transparent rather than hidden constants

## Out of scope

Three other tasks have similar `task_side` patterns identified today (barrier-garch-var, cta-basel-capital, regime-cta-vol-target), but those have **no visible Python oracle in the public repo** — the generator scripts were never committed. Those need a separate upstream contribution before equivalent spec ↔ oracle alignment can be done.

## Test plan

- [ ] CI checks pass on `fix/spec-oracle-alignment`
- [ ] Manually verify `solve_sentiment` and `solve_regime` would produce identical reference values after the param additions (no behavior change in the generator — only spec wording + new params surfacing)
- [ ] Optional follow-up: re-run agents to confirm the spec is now self-consistent